### PR TITLE
vendor agnostic

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,8 +4,8 @@ authors = ["Ben Arthur <arthurb@hhmi.org>"]
 version = "0.2.3"
 
 [deps]
-CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+GPUArrays = "0c68f7d7-f131-5f86-a1c3-88cf8149b2d7"
+KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 
 [compat]
-CUDA = "3, 4"
 julia = "1.6"

--- a/bench/runbench.jl
+++ b/bench/runbench.jl
@@ -5,6 +5,15 @@ macro belapsed_median(args...)
     esc(:(time(median(@benchmark $(args...))) / 1e9))
 end
 
+macro sync(ex)
+    quote
+        local ret = $(esc(ex))
+        KernelAbstractions.synchronize(CUDABackend())
+        ret
+
+    end
+end
+
 
 function doit(L,N)
     x2 = CuArray(rand(L,N));
@@ -14,8 +23,8 @@ function doit(L,N)
     o1 = CuArray(rand(N));
     o3 = CuArray(rand(1,1,N));
 
-    tbgemm = @belapsed_median CUDA.@sync batched_mul!($o3, batched_transpose($x3), $y3)
-    tbdot = @belapsed_median CUDA.@sync batched_dot!($o1, $x2, $y2)
+    tbgemm = @belapsed_median @sync batched_mul!($o3, batched_transpose($x3), $y3)
+    tbdot = @belapsed_median @sync batched_dot!($o1, $x2, $y2)
 
     CUDA.unsafe_free!.((x2, x3, y2, y3, o1, o3))
     CUDA.memory_status()
@@ -51,18 +60,18 @@ function doit(L,N)
     y2 = CuArray(rand(L,N));
     y3 = CuArray(rand(L,1,N));
 
-    tbgemm = @belapsed_median CUDA.@sync batched_mul!($y3, $A3, $x3)
+    tbgemm = @belapsed_median @sync batched_mul!($y3, $A3, $x3)
 
-    tbgemvn = @belapsed_median CUDA.@sync batched_gemv!('N', 1.0, $A3, $x2, 0.0, $y2)
-    tbgemvt = @belapsed_median CUDA.@sync batched_gemv!('T', 1.0, $A3, $x2, 0.0, $y2)
+    tbgemvn = @belapsed_median @sync batched_gemv!('N', 1.0, $A3, $x2, 0.0, $y2)
+    tbgemvt = @belapsed_median @sync batched_gemv!('T', 1.0, $A3, $x2, 0.0, $y2)
 
-    tbsymvu = @belapsed_median CUDA.@sync batched_symv!('U', 1.0, $A3, $x2, 0.0, $y2)
-    tbsymvl = @belapsed_median CUDA.@sync batched_symv!('L', 1.0, $A3, $x2, 0.0, $y2)
+    tbsymvu = @belapsed_median @sync batched_symv!('U', 1.0, $A3, $x2, 0.0, $y2)
+    tbsymvl = @belapsed_median @sync batched_symv!('L', 1.0, $A3, $x2, 0.0, $y2)
 
     AP = CuArray(hcat([SymmetricPacked(x, :U).tri for x in eachslice(_A, dims=3)]...));
-    tbspmvu = @belapsed_median CUDA.@sync batched_spmv!('U', 1.0, $AP, $x2, 0.0, $y2)
+    tbspmvu = @belapsed_median @sync batched_spmv!('U', 1.0, $AP, $x2, 0.0, $y2)
     AP = CuArray(hcat([SymmetricPacked(x, :L).tri for x in eachslice(_A, dims=3)]...));
-    tbspmvl = @belapsed_median CUDA.@sync batched_spmv!('L', 1.0, $AP, $x2, 0.0, $y2)
+    tbspmvl = @belapsed_median @sync batched_spmv!('L', 1.0, $AP, $x2, 0.0, $y2)
 
     CUDA.unsafe_free!.((A3, AP, x2, x3, y2, y3))
     CUDA.memory_status()
@@ -108,17 +117,17 @@ function doit(L,N)
     y2 = CuArray(rand(L,N));
     y3 = CuArray(rand(L,1,N));
 
-    tbgemm = @belapsed_median CUDA.@sync batched_mul!($A3, $x3, batched_transpose($x3), -1.0, 1.0)
+    tbgemm = @belapsed_median @sync batched_mul!($A3, $x3, batched_transpose($x3), -1.0, 1.0)
 
-    tbger = @belapsed_median CUDA.@sync batched_ger!(-1.0, $x2, $y2, $A3)
+    tbger = @belapsed_median @sync batched_ger!(-1.0, $x2, $y2, $A3)
 
-    tbsyru = @belapsed_median CUDA.@sync batched_syr!('U', -1.0, $x2, $A3)
-    tbsyrl = @belapsed_median CUDA.@sync batched_syr!('L', -1.0, $x2, $A3)
+    tbsyru = @belapsed_median @sync batched_syr!('U', -1.0, $x2, $A3)
+    tbsyrl = @belapsed_median @sync batched_syr!('L', -1.0, $x2, $A3)
 
     AP = CuArray(hcat([SymmetricPacked(x, :U).tri for x in eachslice(_A, dims=3)]...));
-    tbspru = @belapsed_median CUDA.@sync batched_spr!('U', -1.0, $x2, $AP)
+    tbspru = @belapsed_median @sync batched_spr!('U', -1.0, $x2, $AP)
     AP = CuArray(hcat([SymmetricPacked(x, :L).tri for x in eachslice(_A, dims=3)]...));
-    tbsprl = @belapsed_median CUDA.@sync batched_spr!('L', -1.0, $x2, $AP)
+    tbsprl = @belapsed_median @sync batched_spr!('L', -1.0, $x2, $AP)
 
     CUDA.unsafe_free!.((A3, AP, x2, x3, y2, y3))
     CUDA.memory_status()

--- a/src/BatchedBLAS.jl
+++ b/src/BatchedBLAS.jl
@@ -1,6 +1,6 @@
 module BatchedBLAS
 
-using CUDA
+using GPUArrays, KernelAbstractions
 
 export batched_dot!
 export batched_gemv!, batched_symv!, batched_spmv!
@@ -13,20 +13,6 @@ maybe_cast(::Type, x) = x
 maybe_cast(::Type{T}, x::AbstractFloat) where T<:Integer =
         round(T, clamp(x, typemin(T), typemax(T)))
 
-function configurator(config, dim1)
-    xthreads = min(32, dim1)
-    xblocks = cld(dim1, xthreads)
-    return (xthreads,), (xblocks,)
-end
-
-function configurator(config, dim1, dim2)
-    xthreads = min(32, dim1)
-    ythreads = min(fld(config.threads, xthreads), cld(dim1*dim2, xthreads))
-    xblocks = cld(dim1, xthreads)
-    yblocks = cld(dim2, ythreads)
-    return (xthreads, ythreads), (xblocks, yblocks)
-end
-
 """
     batched_dot!(o, x, y)
 
@@ -34,27 +20,24 @@ In-place batched vector-vector multiplication, equivalent to
 `o[k] = transpose(x[:,k]) * y[:,k]` for all `k`.  All inputs
 can have eltypes of either AbstractFloats or Integers.
 """
-function batched_dot!(o::CuVector{To}, x::CuMatrix{Tx}, y::CuMatrix{Ty}) where {
-                          To<:IntOrFloat, Tx<:IntOrFloat, Ty<:IntOrFloat}
+function batched_dot!(o::AbstractGPUVector{To}, x::AbstractGPUMatrix{Tx}, y::AbstractGPUMatrix{Ty};
+                      backend=get_backend(o)) where {
+                      To<:IntOrFloat, Tx<:IntOrFloat, Ty<:IntOrFloat}
 
-    function kernel(::Type{T}, o, x, y) where T
-        k = threadIdx().x + (blockIdx().x - 1) * blockDim().x
+    @kernel function kernel(::Type{T}, o, @Const(x), @Const(y)) where T
+        k = @index(Global)
 
-        @inbounds if k<=size(x,2)
+        @inbounds begin
             tmp = T(0)
             for i=1:size(x,1)
                 tmp += x[i,k] * T(y[i,k])
             end
             o[k] = maybe_cast(To, tmp)
         end
-        return nothing
     end
 
     T = promote_type(To, Tx, Ty)
-    kernel = @cuda name="batched_dot!" launch=false kernel(T, o, x, y)
-    config = launch_configuration(kernel.fun)
-    threads, blocks = configurator(config, size(o,1))
-    kernel(T, o, x, y; threads=threads, blocks=blocks)
+    kernel(backend)(T, o, x, y; ndrange=length(o))
 end
 
 """
@@ -67,58 +50,54 @@ All other inputs can have eltypes of either AbstractFloats or Integers.
 `alpha` and `beta` can also be scalars.
 """
 function batched_gemv!(tA::AbstractChar,
-                       alpha::Talpha, A::CuArray{TA,3}, x::CuMatrix{Tx},
-                       beta::Tbeta, y::CuMatrix{Ty}) where {
-                           Talpha<:Union{IntOrFloat, CuVector{<:IntOrFloat}},
+                       alpha::Talpha, A::AbstractGPUArray{TA,3}, x::AbstractGPUMatrix{Tx},
+                       beta::Tbeta, y::AbstractGPUMatrix{Ty};
+                       backend=get_backend(A)) where {
+                           Talpha<:Union{IntOrFloat, AbstractGPUVector{<:IntOrFloat}},
                            TA<:IntOrFloat, Tx<:IntOrFloat,
-                           Tbeta<:Union{IntOrFloat, CuVector{<:IntOrFloat}},
+                           Tbeta<:Union{IntOrFloat, AbstractGPUVector{<:IntOrFloat}},
                            Ty<:IntOrFloat}
 
-    function kernel(::Type{T}, tA, alpha, A, x, beta, y) where T
-        i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
-        k = threadIdx().y + (blockIdx().y - 1) * blockDim().y
+    @kernel function kernel(::Type{T}, @Const(tA), @Const(alpha), @Const(A), @Const(x), @Const(beta), y) where T
+        i, k = @index(Global, NTuple)
 
         if tA=='N'
-            @inbounds if k<=size(y,2) && i<=size(y,1)
+            @inbounds begin
                 tmp = T(0)
                 for j=1:size(x,1)
                     tmp += A[i,j,k] * T(x[j,k])
                 end
-                thisalpha = Talpha<:CuVector ? alpha[k] : alpha
-                thisbeta = Tbeta<:CuVector ? beta[k] : beta
+                thisalpha = Talpha<:AbstractGPUVector ? alpha[k] : alpha
+                thisbeta = Tbeta<:AbstractGPUVector ? beta[k] : beta
                 y[i,k] = maybe_cast(Ty, thisalpha*tmp + thisbeta*y[i,k])
             end
         elseif tA=='T'
-            @inbounds if k<=size(y,2) && i<=size(y,1)
+            @inbounds begin
                 tmp = T(0)
                 for j=1:size(x,1)
                     tmp += A[j,i,k] * T(x[j,k])
                 end
-                thisalpha = Talpha<:CuVector ? alpha[k] : alpha
-                thisbeta = Tbeta<:CuVector ? beta[k] : beta
+                thisalpha = Talpha<:AbstractGPUVector ? alpha[k] : alpha
+                thisbeta = Tbeta<:AbstractGPUVector ? beta[k] : beta
                 y[i,k] = maybe_cast(Ty, thisalpha*tmp + thisbeta*y[i,k])
             end
         elseif tA=='C'
-            @inbounds if k<=size(y,2) && i<=size(y,1)
+            @inbounds begin
                 tmp = T(0)
                 for j=1:size(x,1)
                     tmp += adjoint(A[j,i,k]) * T(x[j,k])
                 end
-                thisalpha = Talpha<:CuVector ? alpha[k] : alpha
-                thisbeta = Tbeta<:CuVector ? beta[k] : beta
+                thisalpha = Talpha<:AbstractGPUVector ? alpha[k] : alpha
+                thisbeta = Tbeta<:AbstractGPUVector ? beta[k] : beta
                 y[i,k] = maybe_cast(Ty, thisalpha*tmp + thisbeta*y[i,k])
             end
         else
             throw(ArgumentError("`tA` should be 'N', 'T', or 'C'"))
         end
-        return nothing
     end
 
     T = promote_type(eltype(Talpha), TA, Tx, eltype(Tbeta), Ty)
-    kernel = @cuda name="batched_gemv!" launch=false kernel(T, tA, alpha, A, x, beta, y)
-    config = launch_configuration(kernel.fun)
-    threads, blocks = configurator(config, size(y,1), size(y,2))
-    kernel(T, tA, alpha, A, x, beta, y; threads=threads, blocks=blocks)
+    kernel(backend)(T, tA, alpha, A, x, beta, y; ndrange=size(y))
 end
 
 """
@@ -131,50 +110,46 @@ is assumed to be symmetric.  Only the `uplo` (either 'U' or 'L') triangle of
 or Integers.  `alpha` and `beta` can also be scalars.
 """
 function batched_symv!(uplo::AbstractChar,
-                       alpha::Talpha, A::CuArray{TA,3}, x::CuMatrix{Tx},
-                       beta::Tbeta, y::CuMatrix{Ty}) where {
-                           Talpha<:Union{IntOrFloat, CuVector{<:IntOrFloat}},
+                       alpha::Talpha, A::AbstractGPUArray{TA,3}, x::AbstractGPUMatrix{Tx},
+                       beta::Tbeta, y::AbstractGPUMatrix{Ty};
+                       backend=get_backend(A)) where {
+                           Talpha<:Union{IntOrFloat, AbstractGPUVector{<:IntOrFloat}},
                            TA<:IntOrFloat, Tx<:IntOrFloat,
-                           Tbeta<:Union{IntOrFloat, CuVector{<:IntOrFloat}},
+                           Tbeta<:Union{IntOrFloat, AbstractGPUVector{<:IntOrFloat}},
                            Ty<:IntOrFloat}
 
-    function kernel(::Type{T}, uplo, alpha, A, x, beta, y) where T
-        i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
-        k = threadIdx().y + (blockIdx().y - 1) * blockDim().y
+    @kernel function kernel(::Type{T}, @Const(uplo), @Const(alpha), @Const(A), @Const(x), @Const(beta), y) where T
+        i, k = @index(Global, NTuple)
 
         if uplo=='U'
-            @inbounds if k<=size(y,2) && i<=size(y,1)
+            @inbounds begin
                 tmp = T(0)
                 for j=1:size(x,1)
                     ijmin,ijmax = minmax(i,j)
                     tmp += A[ijmin,ijmax,k] * T(x[j,k])
                 end
-                thisalpha = Talpha<:CuVector ? alpha[k] : alpha
-                thisbeta = Tbeta<:CuVector ? beta[k] : beta
+                thisalpha = Talpha<:AbstractGPUVector ? alpha[k] : alpha
+                thisbeta = Tbeta<:AbstractGPUVector ? beta[k] : beta
                 y[i,k] = maybe_cast(Ty, thisalpha*tmp + thisbeta*y[i,k])
             end
         elseif uplo=='L'
-            @inbounds if k<=size(y,2) && i<=size(y,1)
+            @inbounds begin
                 tmp = T(0)
                 for j=1:size(x,1)
                     ijmin,ijmax = minmax(i,j)
                     tmp += A[ijmax,ijmin,k] * T(x[j,k])
                 end
-                thisalpha = Talpha<:CuVector ? alpha[k] : alpha
-                thisbeta = Tbeta<:CuVector ? beta[k] : beta
+                thisalpha = Talpha<:AbstractGPUVector ? alpha[k] : alpha
+                thisbeta = Tbeta<:AbstractGPUVector ? beta[k] : beta
                 y[i,k] = maybe_cast(Ty, thisalpha*tmp + thisbeta*y[i,k])
             end
         else
             throw(ArgumentError("`uplo` should be 'U' or 'L'"))
         end
-        return nothing
     end
 
     T = promote_type(eltype(Talpha), TA, Tx, eltype(Tbeta), Ty)
-    kernel = @cuda name="batched_symv!" launch=false kernel(T, uplo, alpha, A, x, beta, y)
-    config = launch_configuration(kernel.fun)
-    threads, blocks = configurator(config, size(y,1), size(y,2))
-    kernel(T, uplo, alpha, A, x, beta, y; threads=threads, blocks=blocks)
+    kernel(backend)(T, uplo, alpha, A, x, beta, y; ndrange=size(y))
 end
 
 """
@@ -187,53 +162,49 @@ or lower ('L') triangle was packed.  All other inputs can have eltypes of
 either AbstractFloats or Integers.  `alpha` and `beta` can also be scalars.
 """
 function batched_spmv!(uplo::AbstractChar,
-                       alpha::Talpha, A::CuMatrix{TA}, x::CuMatrix{Tx},
-                       beta::Tbeta, y::CuMatrix{Ty}) where {
-                         Talpha<:Union{IntOrFloat, CuVector{<:IntOrFloat}},
+                       alpha::Talpha, A::AbstractGPUMatrix{TA}, x::AbstractGPUMatrix{Tx},
+                       beta::Tbeta, y::AbstractGPUMatrix{Ty};
+                       backend=get_backend(A)) where {
+                         Talpha<:Union{IntOrFloat, AbstractGPUVector{<:IntOrFloat}},
                          TA<:IntOrFloat, Tx<:IntOrFloat,
-                         Tbeta<:Union{IntOrFloat, CuVector{<:IntOrFloat}},
+                         Tbeta<:Union{IntOrFloat, AbstractGPUVector{<:IntOrFloat}},
                          Ty<:IntOrFloat}
 
-    function kernel(::Type{T}, uplo, alpha, A, x, beta, y) where T
-        i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
-        k = threadIdx().y + (blockIdx().y - 1) * blockDim().y
+    @kernel function kernel(::Type{T}, @Const(uplo), @Const(alpha), @Const(A), @Const(x), @Const(beta), y) where T
+        i, k = @index(Global, NTuple)
 
         if uplo=='U'
-            @inbounds if k<=size(y,2) && i<=size(y,1)
+            @inbounds begin
                 tmp = T(0)
                 for j=1:size(x,1)
                     ijmin,ijmax = minmax(i,j)
                     h = ijmin+(ijmax*(ijmax-1))>>1
                     tmp += A[h,k] * T(x[j,k])
                 end
-                thisalpha = Talpha<:CuVector ? alpha[k] : alpha
-                thisbeta = Tbeta<:CuVector ? beta[k] : beta
+                thisalpha = Talpha<:AbstractGPUVector ? alpha[k] : alpha
+                thisbeta = Tbeta<:AbstractGPUVector ? beta[k] : beta
                 y[i,k] = maybe_cast(Ty, thisalpha*tmp + thisbeta*y[i,k])
             end
         elseif uplo=='L'
-            n = round(Int, (sqrt(8*size(A,1))-1)/2)
-            @inbounds if k<=size(y,2) && i<=size(y,1)
+            @inbounds begin
+                n = round(Int, (sqrt(8*size(A,1))-1)/2)
                 tmp = T(0)
                 for j=1:size(x,1)
                     ijmin,ijmax = minmax(i,j)
                     h = ijmax+((2n-ijmin)*(ijmin-1))>>1
                     tmp += A[h,k] * T(x[j,k])
                 end
-                thisalpha = Talpha<:CuVector ? alpha[k] : alpha
-                thisbeta = Tbeta<:CuVector ? beta[k] : beta
+                thisalpha = Talpha<:AbstractGPUVector ? alpha[k] : alpha
+                thisbeta = Tbeta<:AbstractGPUVector ? beta[k] : beta
                 y[i,k] = maybe_cast(Ty, thisalpha*tmp + thisbeta*y[i,k])
             end
         else
             throw(ArgumentError("`uplo` should be 'U' or 'L'"))
         end
-        return nothing
     end
 
     T = promote_type(eltype(Talpha), TA, Tx, eltype(Tbeta), Ty)
-    kernel = @cuda name="batched_spmv!" launch=false kernel(T, uplo, alpha, A, x, beta, y)
-    config = launch_configuration(kernel.fun)
-    threads, blocks = configurator(config, size(y,1), size(y,2))
-    kernel(T, uplo, alpha, A, x, beta, y; threads=threads, blocks=blocks)
+    kernel(backend)(T, uplo, alpha, A, x, beta, y; ndrange=size(y))
 end
 
 """
@@ -244,26 +215,25 @@ In-place rank-1 update of matrix `A` with vectors `x` and `y` as
 nputs can have eltypes of either AbstractFloats or Integers.  `alpha`
 can also be a scalar.
 """
-function batched_ger!(alpha::Talpha, x::CuMatrix{Tx}, y::CuMatrix{Ty}, A::CuArray{TA,3}) where {
-                          Talpha<:Union{IntOrFloat, CuVector{<:IntOrFloat}},
+function batched_ger!(alpha::Talpha,
+                      x::AbstractGPUMatrix{Tx}, y::AbstractGPUMatrix{Ty},
+                      A::AbstractGPUArray{TA,3};
+                      backend=get_backend(A)) where {
+                          Talpha<:Union{IntOrFloat, AbstractGPUVector{<:IntOrFloat}},
                           Tx<:IntOrFloat, Ty<:IntOrFloat, TA<:IntOrFloat}
 
-    function kernel(alpha, x, y, A)
-        i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
-        k = threadIdx().y + (blockIdx().y - 1) * blockDim().y
+    @kernel function kernel(@Const(alpha), @Const(x), @Const(y), A)
+        i, k = @index(Global, NTuple)
 
-        @inbounds if k<=size(x,2) && i<=size(x,1)
+        @inbounds begin
             for j=1:size(x,1)
-                thisalpha = Talpha<:CuVector ? alpha[k] : alpha
+                thisalpha = Talpha<:AbstractGPUVector ? alpha[k] : alpha
                 A[i,j,k] += maybe_cast(TA, thisalpha * x[i,k] * y[j,k])
             end
         end
     end
 
-    kernel = @cuda name="batched_ger_vector!" launch=false kernel(alpha, x, y, A)
-    config = launch_configuration(kernel.fun)
-    threads, blocks = configurator(config, size(x,1), size(x,2))
-    kernel(alpha, x, y, A; threads=threads, blocks=blocks)
+    kernel(backend)(alpha, x, y, A; ndrange=size(x))
 end
 
 """
@@ -276,27 +246,27 @@ assumed to be symmetric.  Only the `uplo` (either 'U' or 'L') triangle of
 or Integers.  `alpha` can also be a scalar.
 """
 function batched_syr!(uplo::AbstractChar,
-                      alpha::Talpha, x::CuMatrix{Tx}, A::CuArray{TA,3}) where {
-                          Talpha<:Union{IntOrFloat, CuVector{<:IntOrFloat}},
+                      alpha::Talpha, x::AbstractGPUMatrix{Tx}, A::AbstractGPUArray{TA,3};
+                      backend=get_backend(A)) where {
+                          Talpha<:Union{IntOrFloat, AbstractGPUVector{<:IntOrFloat}},
                           Tx<:IntOrFloat, TA<:IntOrFloat}
 
-    function kernel(uplo, alpha, x, A)
-        i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
-        k = threadIdx().y + (blockIdx().y - 1) * blockDim().y
+    @kernel function kernel(@Const(uplo), @Const(alpha), @Const(x), A)
+        i, k = @index(Global, NTuple)
 
         if uplo=='U'
-            @inbounds if k<=size(x,2) && i<=size(x,1)
+            @inbounds begin
                 for j=size(x,1):-1:1
                     j<i && break
-                    thisalpha = Talpha<:CuVector ? alpha[k] : alpha
+                    thisalpha = Talpha<:AbstractGPUVector ? alpha[k] : alpha
                     A[i,j,k] += maybe_cast(TA, thisalpha * x[i,k] * x[j,k])
                 end
             end
         elseif uplo=='L'
-            @inbounds if k<=size(x,2) && i<=size(x,1)
+            @inbounds begin
                 for j=1:size(x,1)
                     j>i && break
-                    thisalpha = Talpha<:CuVector ? alpha[k] : alpha
+                    thisalpha = Talpha<:AbstractGPUVector ? alpha[k] : alpha
                     A[i,j,k] += maybe_cast(TA, thisalpha * x[i,k] * x[j,k])
                 end
             end
@@ -305,10 +275,7 @@ function batched_syr!(uplo::AbstractChar,
         end
     end
 
-    kernel = @cuda name="batched_syr_vector!" launch=false kernel(uplo, alpha, x, A)
-    config = launch_configuration(kernel.fun)
-    threads, blocks = configurator(config, size(x,1), size(x,2))
-    kernel(uplo, alpha, x, A; threads=threads, blocks=blocks)
+    kernel(backend)(uplo, alpha, x, A; ndrange=size(x))
 end
 
 """
@@ -321,30 +288,30 @@ must be symmetric, and `uplo` specifies whether the upper ('U') or lower
 AbstractFloats or Integers.  `alpha` can also be a scalar.
 """
 function batched_spr!(uplo::AbstractChar,
-                      alpha::Talpha, x::CuMatrix{Tx}, A::CuMatrix{TA}) where {
-                          Talpha<:Union{IntOrFloat, CuVector{<:IntOrFloat}},
+                      alpha::Talpha, x::AbstractGPUMatrix{Tx}, A::AbstractGPUMatrix{TA};
+                      backend=get_backend(A)) where {
+                          Talpha<:Union{IntOrFloat, AbstractGPUVector{<:IntOrFloat}},
                           Tx<:IntOrFloat, TA<:IntOrFloat}
 
-    function kernel(uplo, alpha, x, A)
-        i = threadIdx().x + (blockIdx().x - 1) * blockDim().x
-        k = threadIdx().y + (blockIdx().y - 1) * blockDim().y
+    @kernel function kernel(@Const(uplo), @Const(alpha), @Const(x), A)
+        i, k = @index(Global, NTuple)
 
         if uplo=='U'
-            @inbounds if k<=size(x,2) && i<=size(x,1)
+            @inbounds begin
                 for j=size(x,1):-1:1
                     j<i && break
                     h = i+(j*(j-1))>>1
-                    thisalpha = Talpha<:CuVector ? alpha[k] : alpha
+                    thisalpha = Talpha<:AbstractGPUVector ? alpha[k] : alpha
                     A[h,k] += maybe_cast(TA, thisalpha * x[i,k] * x[j,k])
                 end
             end
         elseif uplo=='L'
-            n = round(Int, (sqrt(8*size(A,1))-1)/2)
-            @inbounds if k<=size(x,2) && i<=size(x,1)
+            @inbounds begin
+                n = round(Int, (sqrt(8*size(A,1))-1)/2)
                 for j=1:size(x,1)
                     j>i && break
                     h = i+((2n-j)*(j-1))>>1
-                    thisalpha = Talpha<:CuVector ? alpha[k] : alpha
+                    thisalpha = Talpha<:AbstractGPUVector ? alpha[k] : alpha
                     A[h,k] += maybe_cast(TA, thisalpha * x[i,k] * x[j,k])
                 end
             end
@@ -353,10 +320,7 @@ function batched_spr!(uplo::AbstractChar,
         end
     end
 
-    kernel = @cuda name="batched_spr_vector!" launch=false kernel(uplo, alpha, x, A)
-    config = launch_configuration(kernel.fun)
-    threads, blocks = configurator(config, size(x,1), size(x,2))
-    kernel(uplo, alpha, x, A; threads=threads, blocks=blocks)
+    kernel(backend)(uplo, alpha, x, A; ndrange=size(x))
 end
 
 end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,9 @@
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 SymmetricFormats = "a91e544d-b3d6-4431-ae28-0549b1291c16"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[compat]
+CUDA = "3, 4"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
-using BatchedBLAS, Test, CUDA, LinearAlgebra, LinearAlgebra.BLAS, SymmetricFormats
+using BatchedBLAS, Test, LinearAlgebra, LinearAlgebra.BLAS, SymmetricFormats
+using KernelAbstractions, CUDA
 
 L=16; N=4
 A = reshape(1.0:L*L*N, L,L,N);


### PR DESCRIPTION
not merged yet because benchmarks are slower by ~10%:

<img width="771" alt="Screenshot 2023-04-25 at 4 35 39 PM" src="https://user-images.githubusercontent.com/1538268/234397602-457df10c-0437-43b4-9885-6aa6ece8b6d2.png">

the huge regression in `batched_dot` can partially be fixed by specifying `CUDABackend(prefer_blocks=true)`, but this then is not vendor agnostic.  see https://discourse.julialang.org/t/kernelabstractions-get-backend-keyword-arguments/97895